### PR TITLE
Changes colour of invisibles,wrap and margin guide

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -8,9 +8,9 @@
 @syntax-background-color: #0d2839;
 
 // Guide colors
-@syntax-wrap-guide-color: #546A68;
-@syntax-indent-guide-color: #546A68;
-@syntax-invisible-character-color: #546A68;
+@syntax-wrap-guide-color: #234154;
+@syntax-indent-guide-color: #234154;
+@syntax-invisible-character-color: #234154;
 
 // For find and replace markers
 @syntax-result-marker-color: #546A68;


### PR DESCRIPTION
I find the default colour of invisibles and the wrap guide a little obtrusive. This change makes them a lighter shade of the background colour. 

See what you think.
![screenshot from 2015-06-08 22-32-54](https://cloud.githubusercontent.com/assets/7274458/8045962/20ebb92a-0e2f-11e5-9c8d-6c950fb985e7.png)
